### PR TITLE
Create Node Charts for CPU and Memory

### DIFF
--- a/client/Components/LineChart/LineGraph.jsx
+++ b/client/Components/LineChart/LineGraph.jsx
@@ -4,7 +4,8 @@ import * as d3 from 'd3';
 import { selectAll } from 'd3-selection';
 
 const LineGraph = ({ dataRef, yaxis, propertyName, legendName }) => {
-  const svgRef = useRef(); //creating a variable to connect the ref prop that we
+  const svgRef = useRef();
+  console.log(propertyName)
   function initialize(width, height) {
 
     var margin = { top: 20, right: 175, bottom: 50, left: 100 },

--- a/client/Components/LineChart/LineGraph.jsx
+++ b/client/Components/LineChart/LineGraph.jsx
@@ -3,9 +3,8 @@ import { nest } from 'd3-collection';
 import * as d3 from 'd3';
 import { selectAll } from 'd3-selection';
 
-const LineGraph = ({ dataRef, yaxis, propertyName, legendName }) => {
+const LineGraph = ({ dataRef, yaxis, propertyName, legendName, title }) => {
   const svgRef = useRef();
-  console.log(propertyName)
   function initialize(width, height) {
 
     var margin = { top: 20, right: 175, bottom: 50, left: 100 },
@@ -90,7 +89,6 @@ const LineGraph = ({ dataRef, yaxis, propertyName, legendName }) => {
     let sumStat = nest()
       .key(function (d) { return d.name })
       .entries(data);
-    // console.log('SUMSTAT', sumStat);
 
 
     //   // add the Line
@@ -229,7 +227,7 @@ const LineGraph = ({ dataRef, yaxis, propertyName, legendName }) => {
 
     // initialize
     var now = new Date();
-    const width = 1050;
+    const width = 900;
     const graphVars = initialize(width, width * 0.7);
 
     var lookback = new Date(now); // creates a copy of now's date
@@ -251,7 +249,12 @@ const LineGraph = ({ dataRef, yaxis, propertyName, legendName }) => {
     };
   }, []);
 
-  return <svg ref={svgRef}></svg>;
+  return (
+    <div className='flex flex-col items-center justify-center'>
+      <h2 className='text-2xl'>{title}</h2>
+      <svg ref={svgRef}></svg>
+    </div>
+  )
 };
 
 export default LineGraph;

--- a/client/Components/LineChart/LineGraph.jsx
+++ b/client/Components/LineChart/LineGraph.jsx
@@ -3,10 +3,13 @@ import { nest } from 'd3-collection';
 import * as d3 from 'd3';
 import { selectAll } from 'd3-selection';
 
-const LineGraph = ({ dataRef, yaxis, legendName }) => {
+const LineGraph = ({ dataRef, yaxis, propertyName, legendName }) => {
   const svgRef = useRef(); //creating a variable to connect the ref prop that we
-  const y = useRef('');
-  if (dataRef['current'][0]) (y.current = (Object.keys(dataRef['current'][0])[1]));
+  // const y = useRef('');
+  // if (dataRef['current'][0]) (y.current = (Object.keys(dataRef['current'][0])[1]));
+  // if (dataRef['current'][0]) console.log(Object.keys(dataRef.current[0]));
+  // y.current = propertyName;
+  console.log(propertyName)
   function initialize(width, height) {
 
     var margin = { top: 20, right: 175, bottom: 50, left: 100 },
@@ -89,7 +92,7 @@ const LineGraph = ({ dataRef, yaxis, legendName }) => {
 
 
     let sumStat = nest()
-      .key(function (d) { return d.podName })
+      .key(function (d) { return d.name })
       .entries(data);
     // console.log('SUMSTAT', sumStat);
 
@@ -108,13 +111,13 @@ const LineGraph = ({ dataRef, yaxis, legendName }) => {
       .scaleLinear()
       .domain([
         d3.min(data, (d) => {
-          if (y.current === 'cpuCurrentUsage') {
+          if (propertyName === 'cpuCurrentUsage') {
             return -.00000001;
           }
-          return d[`${y.current}`] / 4;
+          return d[`${propertyName}`] / 4;
         }),
         d3.max(data, (d) => {
-          return d[`${y.current}`] * 1.2;
+          return d[`${propertyName}`] * 1.2;
         }),
       ])
       .range([graph.attr('height') - room_for_axis, 0]); // range deals with the position of where things get plotted (area)
@@ -167,7 +170,7 @@ const LineGraph = ({ dataRef, yaxis, legendName }) => {
         return xScale(d.timestamp);
       })
       .y((d) => {
-        return yScale(d[`${y.current}`]);
+        return yScale(d[`${propertyName}`]);
       });
     circleGroup
       .selectAll('.temp-path')
@@ -194,7 +197,7 @@ const LineGraph = ({ dataRef, yaxis, legendName }) => {
         return xScale(d.timestamp); //tells us where on the graph that the plot should be relative to the chart's width.
       })
       .attr('cy', function (d) {
-        return yScale(d[`${y.current}`]); // tells us where on the graph that the plot should be relative to chart's height.
+        return yScale(d[`${propertyName}`]); // tells us where on the graph that the plot should be relative to chart's height.
       })
       .attr('r', radius)
       .attr('clip-path', 'url(#rectangle-clip)') // clip the rectangle

--- a/client/Components/LineChart/LineGraph.jsx
+++ b/client/Components/LineChart/LineGraph.jsx
@@ -5,11 +5,6 @@ import { selectAll } from 'd3-selection';
 
 const LineGraph = ({ dataRef, yaxis, propertyName, legendName }) => {
   const svgRef = useRef(); //creating a variable to connect the ref prop that we
-  // const y = useRef('');
-  // if (dataRef['current'][0]) (y.current = (Object.keys(dataRef['current'][0])[1]));
-  // if (dataRef['current'][0]) console.log(Object.keys(dataRef.current[0]));
-  // y.current = propertyName;
-  console.log(propertyName)
   function initialize(width, height) {
 
     var margin = { top: 20, right: 175, bottom: 50, left: 100 },

--- a/client/Pages/Home/HomePage.jsx
+++ b/client/Pages/Home/HomePage.jsx
@@ -20,7 +20,9 @@ export default function HomePage({ socket }) {
   const dataRefMem = useRef([]);
   const podRef = useRef([]);
   const nodeCPURef = useRef([]);
+  const nodeCPUPercentRef = useRef([]);
   const nodeMemRef = useRef([]);
+  const nodeMemPercentRef = useRef([])
   const [log, setLog] = useState([{ id: 1, header: '', message: '' }]);
 
   useEffect(() => {
@@ -53,8 +55,10 @@ export default function HomePage({ socket }) {
           name: el.node,
           cpuCurrentUsage: el.cpuCurrentUsage,
           cpuTotal: el.cpuTotal,
+          cpuPercentage: el.cpuCurrentUsage / el.cpuTotal,
           memoryCurrentUsage: el.memoryCurrentUsage,
           memoryTotal: el.memoryTotal,
+          memoryPercentage: el.memoryCurrentUsage / el.memoryTotal,
           timestamp: strictIsoParse(new Date().toISOString()),
         }
       })
@@ -77,7 +81,9 @@ export default function HomePage({ socket }) {
       dataRef.current.push(...pods);
       dataRefMem.current.push(...mapArrayMem);
       nodeCPURef.current.push(...nodes);
+      nodeCPUPercentRef.current.push(...nodes);
       nodeMemRef.current.push(...nodes);
+      nodeMemPercentRef.current.push(...nodes);
       const newPods = metrics.topPods.map((el) => el.pod);
       if (podRef.current !== newPods) {
         podRef.current = [...newPods];
@@ -108,7 +114,9 @@ export default function HomePage({ socket }) {
     dataRef.current = [];
     dataRefMem.current = [];
     nodeCPURef.current = [];
+    nodeCPUPercentRef.current = [];
     nodeMemRef.current = [];
+    nodeMemPercentRef.current = [];
     //empty log data from last namespace
     setLog([{ id: 1, header: '', message: '' }]);
   }, [currentNamespace]);
@@ -126,8 +134,12 @@ export default function HomePage({ socket }) {
       <LineGraph dataRef={dataRefMem} yaxis={'Memory (Bytes)'} propertyName='memoryCurrentUsage' legendName='Pod Names Legend' />
       <h2>Node CPU Usage</h2>
       <LineGraph dataRef={nodeCPURef} yaxis='CPU (Cores)' propertyName='cpuCurrentUsage' legendName='Node Names Legend' />
+      <h2>Node CPU % Over Total</h2>
+      <LineGraph dataRef={nodeCPUPercentRef} yaxis={'CPU Usage (%)'} propertyName='cpuPercentage' legendName='Node Names Legend' />
       <h2>Node Memory Usage</h2>
       <LineGraph dataRef={nodeMemRef} yaxis={'Memory (Bytes)'} propertyName='memoryCurrentUsage' legendName='Node Names Legend' />
+      <h2>Node Memory % Over Total</h2>
+      <LineGraph dataRef={nodeMemPercentRef} yaxis={'Memory Usage (%)'} propertyName='memoryPercentage' legendName='Node Names Legend' />
       <DropdownPods changePods={setCurrentPod} pods={podRef.current} />
       <LogDashboard log={log} />
     </>

--- a/client/Pages/Home/HomePage.jsx
+++ b/client/Pages/Home/HomePage.jsx
@@ -16,13 +16,9 @@ export default function HomePage({ socket }) {
   const [currentPod, setCurrentPod] = useState('');
   const [currentNamespace, setCurrentNamespace] = useState('default');
   const namespacesRef = useRef([]);
-  const dataRef = useRef([]);
-  const dataRefMem = useRef([]);
   const podRef = useRef([]);
-  const nodeCPURef = useRef([]);
-  const nodeCPUPercentRef = useRef([]);
-  const nodeMemRef = useRef([]);
-  const nodeMemPercentRef = useRef([])
+  const podNamesRef = useRef([]);
+  const nodeRef = useRef([]);
   const [log, setLog] = useState([{ id: 1, header: '', message: '' }]);
 
   useEffect(() => {
@@ -66,27 +62,15 @@ export default function HomePage({ socket }) {
         return {
           name: el.pod,
           cpuCurrentUsage: el.cpuCurrentUsage,
-          // memoryCurrentUsage: el.memoryCurrentUsage,
-          timestamp: strictIsoParse(new Date().toISOString()),
-        };
-      });
-      const mapArrayMem = metrics.topPods.map((el) => {
-        return {
-          name: el.pod,
-          // cpuCurrentUsage: el.cpuCurrentUsage,
           memoryCurrentUsage: el.memoryCurrentUsage,
           timestamp: strictIsoParse(new Date().toISOString()),
         };
       });
-      dataRef.current.push(...pods);
-      dataRefMem.current.push(...mapArrayMem);
-      nodeCPURef.current.push(...nodes);
-      nodeCPUPercentRef.current.push(...nodes);
-      nodeMemRef.current.push(...nodes);
-      nodeMemPercentRef.current.push(...nodes);
+      podRef.current.push(...pods);
+      nodeRef.current.push(...nodes);
       const newPods = metrics.topPods.map((el) => el.pod);
-      if (podRef.current !== newPods) {
-        podRef.current = [...newPods];
+      if (podNamesRef.current !== newPods) {
+        podNamesRef.current = [...newPods];
       }
     });
   }, [socket]);
@@ -111,12 +95,8 @@ export default function HomePage({ socket }) {
 
   useEffect(() => {
     //empty data from chart for pods in last namespace
-    dataRef.current = [];
-    dataRefMem.current = [];
-    nodeCPURef.current = [];
-    nodeCPUPercentRef.current = [];
-    nodeMemRef.current = [];
-    nodeMemPercentRef.current = [];
+    podRef.current = [];
+    nodeRef.current = [];
     //empty log data from last namespace
     setLog([{ id: 1, header: '', message: '' }]);
   }, [currentNamespace]);
@@ -128,19 +108,20 @@ export default function HomePage({ socket }) {
         changeNamespace={setCurrentNamespace}
         namespaces={namespacesRef.current}
       />
-      <h2>Pod CPU Usage</h2>
-      <LineGraph dataRef={dataRef} yaxis='CPU (Cores)' propertyName='cpuCurrentUsage' legendName='Pod Names Legend' />
-      <h2>Pod Memory Usage</h2>
-      <LineGraph dataRef={dataRefMem} yaxis={'Memory (Bytes)'} propertyName='memoryCurrentUsage' legendName='Pod Names Legend' />
-      <h2>Node CPU Usage</h2>
-      <LineGraph dataRef={nodeCPURef} yaxis='CPU (Cores)' propertyName='cpuCurrentUsage' legendName='Node Names Legend' />
-      <h2>Node CPU % Over Total</h2>
-      <LineGraph dataRef={nodeCPUPercentRef} yaxis={'CPU Usage (%)'} propertyName='cpuPercentage' legendName='Node Names Legend' />
-      <h2>Node Memory Usage</h2>
-      <LineGraph dataRef={nodeMemRef} yaxis={'Memory (Bytes)'} propertyName='memoryCurrentUsage' legendName='Node Names Legend' />
-      <h2>Node Memory % Over Total</h2>
-      <LineGraph dataRef={nodeMemPercentRef} yaxis={'Memory Usage (%)'} propertyName='memoryPercentage' legendName='Node Names Legend' />
-      <DropdownPods changePods={setCurrentPod} pods={podRef.current} />
+
+      <div className='flex flex-wrap items-center justify-center'>
+        <LineGraph dataRef={podRef} yaxis='CPU (Cores)' propertyName='cpuCurrentUsage' legendName='Pod Names Legend' title='Pod CPU Usage' />
+        <LineGraph dataRef={podRef} yaxis={'Memory (Bytes)'} propertyName='memoryCurrentUsage' legendName='Pod Names Legend' title='Pod Memory Usage' />
+      </div>
+      <div className='flex flex-wrap items-center justify-center'>
+        <LineGraph dataRef={nodeRef} yaxis='CPU (Cores)' propertyName='cpuCurrentUsage' legendName='Node Names Legend' title='Node CPU Usage' />
+        <LineGraph dataRef={nodeRef} yaxis={'CPU Usage (%)'} propertyName='cpuPercentage' legendName='Node Names Legend' title='Node CPU % Over Total' />
+      </div>
+      <div className='flex flex-wrap items-center justify-center'>
+        <LineGraph dataRef={nodeRef} yaxis={'Memory (Bytes)'} propertyName='memoryCurrentUsage' legendName='Node Names Legend' title='Node Memory Usage' />
+        <LineGraph dataRef={nodeRef} yaxis={'Memory Usage (%)'} propertyName='memoryPercentage' legendName='Node Names Legend' title='Node Memory % Over Total' />
+      </div>
+      <DropdownPods changePods={setCurrentPod} pods={podNamesRef.current} />
       <LogDashboard log={log} />
     </>
   );

--- a/client/Pages/Home/HomePage.jsx
+++ b/client/Pages/Home/HomePage.jsx
@@ -20,6 +20,7 @@ export default function HomePage({ socket }) {
   const dataRefMem = useRef([]);
   const podRef = useRef([]);
   const nodeCPURef = useRef([]);
+  const nodeMemRef = useRef([]);
   const [log, setLog] = useState([{ id: 1, header: '', message: '' }]);
 
   useEffect(() => {
@@ -75,7 +76,8 @@ export default function HomePage({ socket }) {
       });
       dataRef.current.push(...pods);
       dataRefMem.current.push(...mapArrayMem);
-      nodeCPURef.current.push(...nodes); // need to verify we push all data or just some
+      nodeCPURef.current.push(...nodes);
+      nodeMemRef.current.push(...nodes);
       const newPods = metrics.topPods.map((el) => el.pod);
       if (podRef.current !== newPods) {
         podRef.current = [...newPods];
@@ -105,7 +107,8 @@ export default function HomePage({ socket }) {
     //empty data from chart for pods in last namespace
     dataRef.current = [];
     dataRefMem.current = [];
-    nodeCPURef.current = []
+    nodeCPURef.current = [];
+    nodeMemRef.current = [];
     //empty log data from last namespace
     setLog([{ id: 1, header: '', message: '' }]);
   }, [currentNamespace]);
@@ -117,12 +120,14 @@ export default function HomePage({ socket }) {
         changeNamespace={setCurrentNamespace}
         namespaces={namespacesRef.current}
       />
-      <h2>Pod CPU</h2>
+      <h2>Pod CPU Usage</h2>
       <LineGraph dataRef={dataRef} yaxis='CPU (Cores)' propertyName='cpuCurrentUsage' legendName='Pod Names Legend' />
-      <h2>Pod Memory</h2>
+      <h2>Pod Memory Usage</h2>
       <LineGraph dataRef={dataRefMem} yaxis={'Memory (Bytes)'} propertyName='memoryCurrentUsage' legendName='Pod Names Legend' />
-      <h2>Node CPU</h2>
-      <LineGraph nodeCPURef={nodeCPURef} yaxis='CPU (Cores)' propertyName='cpuCurrentUsage' legendName='Node Names Legend' />
+      <h2>Node CPU Usage</h2>
+      <LineGraph dataRef={nodeCPURef} yaxis='CPU (Cores)' propertyName='cpuCurrentUsage' legendName='Node Names Legend' />
+      <h2>Node Memory Usage</h2>
+      <LineGraph dataRef={nodeMemRef} yaxis={'Memory (Bytes)'} propertyName='memoryCurrentUsage' legendName='Node Names Legend' />
       <DropdownPods changePods={setCurrentPod} pods={podRef.current} />
       <LogDashboard log={log} />
     </>


### PR DESCRIPTION
[Create node charts and fix chart position](https://app.asana.com/0/1204925741328139/1205116593315193/f)
- Created 4 additional charts: Node CPU usage, Node CPU % Over Total, Node Memory usage, and Node Memory % Over Total
- Adjusted position of the charts to display in a two-column format
- Passed 'propertyName' and 'title' as props to modularize LineGraph component
- Removed dataRefMem and renamed dataRef to podRef
- Renamed podRef to podNameRef for the pod name dropdown menu button
![localhost_8080_home](https://github.com/oslabs-beta/KuberSee/assets/124442983/1ac97897-f9bf-45a0-a3c5-7d739ab485bc)
